### PR TITLE
Version file fixes

### DIFF
--- a/GameData/B9_Aerospace_ProceduralWings/Plugins/B9_Aerospace_WingStuff.version
+++ b/GameData/B9_Aerospace_ProceduralWings/Plugins/B9_Aerospace_WingStuff.version
@@ -6,18 +6,18 @@
     "KSP_VERSION":
     {
         "MAJOR":1,
-        "MINOR":9,
+        "MINOR":10,
         "PATCH":1
     },
     "KSP_VERSION_MIN":
     {
         "MAJOR":1,
-        "MINOR":4,
+        "MINOR":10,
         "PATCH":0
     },
     "KSP_VERSION_MAX":
     {
         "MAJOR":1,
-        "MINOR":9,
-        "PATCH":9
+        "MINOR":10,
+        "PATCH":1
     }}

--- a/GameData/B9_Aerospace_ProceduralWings/Plugins/B9_Aerospace_WingStuff.version
+++ b/GameData/B9_Aerospace_ProceduralWings/Plugins/B9_Aerospace_WingStuff.version
@@ -1,4 +1,9 @@
-{"NAME":"B9 Aerospace Procedural Parts","URL":"https://raw.githubusercontent.com/jrodrigv/B9-PWings-Fork/master/GameData/B9_Aerospace_ProceduralWings/Plugins/B9_Aerospace_WingStuff.version","DOWNLOAD":"https://github.com/jrodrigv/B9-PWings-Fork/releases","VERSION":{"MAJOR":0,"MINOR":92,"PATCH":0},"KSP_VERSION":
+{
+    "NAME":"B9 Aerospace Procedural Parts",
+    "URL":"https://github.com/tetraflon/B9-PWings-Modified/raw/master/GameData/B9_Aerospace_ProceduralWings/Plugins/B9_Aerospace_WingStuff.version",
+    "DOWNLOAD":"https://github.com/tetraflon/B9-PWings-Modified/releases/download/0.40alpha/B9PWM.0.40alpha.zip",
+    "VERSION":{"MAJOR":0,"MINOR":40,"PATCH":0},
+    "KSP_VERSION":
     {
         "MAJOR":1,
         "MINOR":9,


### PR DESCRIPTION
While reviewing KSP-CKAN/NetKAN#8144, I noticed several problems with the version file.

- URL points to the old fork, now it points to the new one
- DOWNLOAD points to the old fork, now it points to the new one
- VERSION does not match the version number of the release, now it's fixed
- KSP_VERSION, KSP_VERSION_MIN, and KSP_VERSION_MAX don't match the versions shown on SpaceDock, now they're fixed

Tagging @tetraflon to ensure that GitHub sends notifications.